### PR TITLE
Remove mod web to fix compilation error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,5 +15,3 @@ pub use scale::*;
 pub use settings::*;
 pub use theme::*;
 pub use version::*;
-
-mod web;


### PR DESCRIPTION
Hi @Twinside, great work on Rem8xer! Thanks for making the code available. This is a tiny PR, I think the `mod web` line was left over from Rem8xer and was causing a compilation error when trying to run the example. Compiles and runs ok after removing it.